### PR TITLE
Fixes for updating apt-get and SciPy 1.3.0

### DIFF
--- a/duckietown-pytorch-rl/container/Dockerfile
+++ b/duckietown-pytorch-rl/container/Dockerfile
@@ -22,6 +22,7 @@ ARG REGION=us-east-1
 FROM 520713654638.dkr.ecr.$REGION.amazonaws.com/sagemaker-pytorch:0.4.0-cpu-py3
 
 # Installs for gym-duckietown
+RUN apt=get update
 RUN apt-get install -y freeglut3-dev xvfb xorg-dev libglu1-mesa libgl1-mesa-dev libxinerama1 libxcursor1
 RUN git clone -b aido1_lf1_r3-v3 https://github.com/duckietown/gym-duckietown src/gym-duckietown
 RUN pip install -e src/gym-duckietown/

--- a/duckietown-pytorch-rl/container/duckietown-rl/wrappers.py
+++ b/duckietown-pytorch-rl/container/duckietown-rl/wrappers.py
@@ -1,7 +1,8 @@
 import gym
 from gym import spaces
 import numpy as np
-
+import PIL
+from PIL import Image
 
 class ResizeWrapper(gym.ObservationWrapper):
     def __init__(self, env=None, shape=(120, 160, 3)):
@@ -15,9 +16,7 @@ class ResizeWrapper(gym.ObservationWrapper):
         self.shape = shape
 
     def observation(self, observation):
-        from scipy.misc import imresize
-        return imresize(observation, self.shape)
-
+        return np.array(Image.fromarray(observation).resize(self.shape[0:2]))
 
 class NormalizeWrapper(gym.ObservationWrapper):
     def __init__(self, env=None):


### PR DESCRIPTION
There are two fixes in this pull request

1. A simple "RUN apt-get update" addition to the container/Dockerfile so that all links can be updated before creating the container.
2. scipy.misc.imresize has been deprecated, using PIL instead

 